### PR TITLE
Add European biogeographic regions to region definitions

### DIFF
--- a/definitions/region/biogeographic-regions.yaml
+++ b/definitions/region/biogeographic-regions.yaml
@@ -1,13 +1,31 @@
 # Source: https://en.wikipedia.org/wiki/Biogeographic_regions_of_Europe
 - Biogeographic regions (Europe):
-    - Arctic
-    - Atlantic
-    - Boreal
-    - Continental
-    - Alpine
-    - Pannonian
-    - Steppic
-    - Black Sea
-    - Mediterranean
-    - Macaronesian
-    - Anatolian
+    - Arctic:
+        countries: Iceland, Norway, Russia
+    - Atlantic:
+        countries: Belgium, Germany, Denmark, Spain, France, Ireland, Portugal,
+          Netherlands, United Kingdom
+    - Boreal:
+        countries: Estonia, Finland, Latvia, Lithuania, Sweden, Belarus, Russia
+    - Continental:
+        countries: Austria, Belgium, Bulgaria, Czech Republic, Germany, Denmark, France,
+          Italy, Luxembourg, Poland, Romania, Sweden, Slovenia, Belarus, Ukraine,
+          Russia, Moldova, Serbia
+    - Alpine:
+        countries: Austria, Bulgaria, Germany, Spain, Finland, France, Italy, Poland,
+          Romania, Sweden, Slovenia, Slovakia, Ukraine, Russia, Georgia, Armenia
+        mountain_ranges: Alps, Pyrenees, Carpathians, Dinaric Alps, Balkans, Rhodopes,
+          Sondes, Urals, Caucasia
+    - Pannonian:
+        countries: Czech Republic, Hungary, Romania, Serbia, Slovakia, Ukraine
+    - Steppic:
+        countries: Romania, Moldova, Ukraine, Russia
+    - Black Sea:
+        countries: Bulgaria, Romania, Turkey, Georgia
+    - Mediterranean:
+        countries: Cyprus, Spain, France, Greece, Italy, Malta, Portugal, Turkey
+    - Macaronesian:
+        countries: Spain, Portugal
+        mountain_ranges: Azores, Madeira, Canaries islands
+    - Anatolian:
+        countries: Turkey

--- a/definitions/region/biogeographic-regions.yaml
+++ b/definitions/region/biogeographic-regions.yaml
@@ -1,0 +1,13 @@
+# Source: https://en.wikipedia.org/wiki/Biogeographic_regions_of_Europe
+- Biogeographic regions (Europe):
+    - Arctic
+    - Atlantic
+    - Boreal
+    - Continental
+    - Alpine
+    - Pannonian
+    - Steppic
+    - Black Sea
+    - Mediterranean
+    - Macaronesian
+    - Anatolian


### PR DESCRIPTION
This PR adds the list of biographic European regions to the region-definitions such that they can be used with timeseries data in the IAMC format.

Are there other attributes that should be added here? Or do we need to add a more elaborate description of the source?

fyi @iiasa/natura-connect-admin 